### PR TITLE
optimize css

### DIFF
--- a/src/skin-lion/ui.fancytree.css
+++ b/src/skin-lion/ui.fancytree.css
@@ -232,23 +232,6 @@ span.fancytree-icon /* Default icon */
 	text-decoration: none;
 	cursor: pointer;
 }
-span.fancytree-focused .fancytree-title {
-	outline: 1px dotted black;
-	color: white;
-}
-span.fancytree-selected .fancytree-title,
-span.fancytree-active .fancytree-title {
-	background-color: #D4D4D4; /*gray*/
-}
-span.fancytree-selected .fancytree-title {
-	font-style: italic;
-}
-.fancytree-focused span.fancytree-selected .fancytree-title,
-.fancytree-focused span.fancytree-active .fancytree-title {
-	color: white;
-	background-color: #3875D7; /*blue*/
-}
-
 /*******************************************************************************
  * 'table' extension
  */


### PR DESCRIPTION
![image1](https://f.cloud.github.com/assets/1462539/838014/77f847ca-f314-11e2-884a-7649f0f9e2b7.PNG)
https://github.com/mar10/fancytree/issues/39

Removed CSS so that it closely matches the images.
