### PR TITLE
Fixed unselectable selectMode=3

### DIFF
--- a/src/jquery.fancytree.js
+++ b/src/jquery.fancytree.js
@@ -546,7 +546,7 @@ FancytreeNode.prototype = /**@lends FancytreeNode*/{
 //		this.debug("fixSelection3AfterClick()");
 
 		this.visit(function(node){
-			node._changeSelectStatusAttrs(flag);
+			if(node.unselectable != true){node._changeSelectStatusAttrs(flag);}
 		});
 		this.fixSelection3FromEndNodes();
 	},


### PR DESCRIPTION
Fixed unselectable selectMode=3.  The original issue is here: https://github.com/mar10/fancytree/issues/45
