### PR TITLE
addChildren update: Assign keys based on position within context of node tree.

### DIFF
--- a/src/jquery.fancytree.js
+++ b/src/jquery.fancytree.js
@@ -297,7 +297,8 @@ FancytreeNode.prototype = /**@lends FancytreeNode*/{
 	addChildren: function(children, insertBefore){
 		var i, l, pos,
 			firstNode = null,
-			nodeList = [];
+			nodeList = [],
+			keyStart, newChild;
 
 		if($.isPlainObject(children) ){
 			children = [children];
@@ -305,8 +306,11 @@ FancytreeNode.prototype = /**@lends FancytreeNode*/{
 		if(!this.children){
 			this.children = [];
 		}
+		keyStart = insertBefore ? this._findDirectChild(insertBefore).getIndex() : this.getChildren().length;
 		for(i=0, l=children.length; i<l; i++){
-			nodeList.push(new FancytreeNode(this, children[i]));
+			newChild = children[i];
+			newChild.key = this.getKeyPath().split('/').pop() + '_' + ++keyStart;
+			nodeList.push(new FancytreeNode(this, newChild));
 		}
 		firstNode = nodeList[0];
 		if(insertBefore == null){


### PR DESCRIPTION
- Assures nodes generated with `addChildren` are assigned the correct key within the context of the tree.
- Tested with and without `insertBefore`, and with arrays of nodes.

The reason for this addition is my application depends on the correct node key being set when I add children to the tree. This allows me to use `myNode.setActive()` on nodes generated with `addChildren`. Previously, the node key would return as '_1', which I was unable to target programmatically.

While looking at the `addChildren` method. It seems to me that it should return `nodeList`, and not `firstNode`. I did not change this as I don't want to make a breaking change unless the team approves.
