### PR TITLE
fix dragging to collapsed nodes

### DIFF
--- a/src/jquery.fancytree.js
+++ b/src/jquery.fancytree.js
@@ -949,6 +949,12 @@ FancytreeNode.prototype = /**@lends FancytreeNode*/{
 				n.tree = targetNode.tree;
 			}, true);
 		}
+
+    // A collaposed node won't re-render children, so we have to remove it manually
+    if( !targetParent.expanded){
+      prevParent.ul.removeChild(this.li);
+    }
+
 		// Update HTML markup
 		if( !prevParent.isDescendantOf(targetParent)) {
 			prevParent.render();


### PR DESCRIPTION
Moving a node to a collapsed node leaves the moved node in its parent.

To reproduce, drag any leaf node on to another leaf node here:

http://wwwendt.de/tech/fancytree/demo/sample-3rd-ui-contextmenu.html#
