### PR TITLE
tabbable nodes (issue #71): fix of the focus frame around expanded node

### DIFF
--- a/src/jquery.fancytree.js
+++ b/src/jquery.fancytree.js
@@ -2304,13 +2304,13 @@ Fancytree.prototype = /**@lends Fancytree*/{
 				if( node.key && opts.generateIds ){
 					node.li.id = opts.idPrefix + node.key;
 				}
-				if( opts.tabbable === "nodes" ){
-					node.li.tabIndex = 0;
-				}
 				node.span = document.createElement("span");
 				node.span.className = "fancytree-node";
 				if(aria){
 					$(node.span).attr("aria-labelledby", "ftal_" + node.key);
+				}
+				if( opts.tabbable === "nodes" ){
+					node.span.tabIndex = 0;
 				}
 				node.li.appendChild(node.span);
 				// Note: we don't add the LI to the DOM know, but only after we
@@ -2798,7 +2798,7 @@ Fancytree.prototype = /**@lends Fancytree*/{
 			}
 			this.nodeMakeVisible(ctx);
 			if(this.options.tabbable === "nodes" && !this._inFocusHandler){
-				$(node.li).focus();
+				$(node.span).focus();
 			}
 			tree.focusNode = node;
 //			node.debug("FOCUS...");

--- a/src/skin-lion/ui.fancytree.css
+++ b/src/skin-lion/ui.fancytree.css
@@ -66,6 +66,11 @@ ul.fancytree-no-connector > li
 	background-color: silver;
 }
 
+span.fancytree-node {
+	display: inline-block;
+	/* uncomment to remove default focused frame */
+	/*outline: 0;*/
+}
 
 /*******************************************************************************
  * Common icon definitions

--- a/src/skin-vista/ui.fancytree.css
+++ b/src/skin-vista/ui.fancytree.css
@@ -77,6 +77,11 @@ ul.fancytree-no-connector > li
 	background-color: silver;
 }
 
+span.fancytree-node {
+	display: inline-block;
+	/* uncomment to remove default focused frame */
+	/*outline: 0;*/
+}
 
 /*******************************************************************************
  * Common icon definitions

--- a/src/skin-win7/ui.fancytree.css
+++ b/src/skin-win7/ui.fancytree.css
@@ -61,6 +61,11 @@ ul.fancytree-no-connector > li
 	background-color: silver;
 }
 
+span.fancytree-node {
+	display: inline-block;
+	/* uncomment to remove default focused frame */
+	/*outline: 0;*/
+}
 
 /*******************************************************************************
  * Common icon definitions

--- a/src/skin-xp/ui.fancytree.css
+++ b/src/skin-xp/ui.fancytree.css
@@ -63,6 +63,12 @@ ul.fancytree-no-connector > li
 	background-color: silver;
 }
 
+span.fancytree-node {
+	display: inline-block;
+	/* uncomment to remove default focused frame */
+	/*outline: 0;*/
+}
+
 /*******************************************************************************
  * Common icon definitions
  */


### PR DESCRIPTION
Changed to focus `<span>` instead of a whole `<li>`. Works but looks badly for most themes, only Win8 theme is ok.  It's necessary to fix css/less in the future. Maybe it will be better to completely remove outline from focused nodes.
