### PR TITLE
add leavesOnly option that filters only by leaves' titles

### DIFF
--- a/src/jquery.fancytree.filter.js
+++ b/src/jquery.fancytree.filter.js
@@ -39,7 +39,7 @@ function _escapeRegex(str){
 $.ui.fancytree._FancytreeClass.prototype.applyFilter = function(filter){
 	var match, re,
 		count = 0,
-		leavesOnly = this.options.filter.leavesOnly;;
+		leavesOnly = this.options.filter.leavesOnly;
 	// Reset current filter
 	this.visit(function(node){
 		delete node.match;


### PR DESCRIPTION
Sometimes there is need to filter tree only by leaves (i.e. when a node doesn't have children).
For that case I added option to filter that by default preserves the old behavior
