### PR TITLE
nodeSetExpanded: support undefined flag

### DIFF
--- a/src/jquery.fancytree.table.js
+++ b/src/jquery.fancytree.table.js
@@ -285,7 +285,8 @@ $.ui.fancytree.registerExtension("table", {
 	/* Expand node, return Deferred.promise. */
 	nodeSetExpanded: function(ctx, flag) {
 		return this._super(ctx, flag).always(function () {
-			setChildRowVisibility(ctx.node, !!flag);
+			flag = (flag !== false);
+			setChildRowVisibility(ctx.node, flag);
 		});
 	},
 	nodeSetStatus: function(ctx, status, message, details) {


### PR DESCRIPTION
I committed the buggy code earlier in #91. When `flag` argument in `nodeSetExpanded` is undefined it should be treated as true. This will fix the bug.
