### PR TITLE
Fix bugs reported in issue #123

### DIFF
--- a/3rd-party/extensions/contextmenu/js/jquery.fancytree.contextMenu.js
+++ b/3rd-party/extensions/contextmenu/js/jquery.fancytree.contextMenu.js
@@ -17,7 +17,7 @@
 			var node = $.ui.fancytree.getNode(event);
 
 			if(node) {
-        $.contextMenu('destroy', "." + selector);
+        $.contextMenu("destroy", "." + selector);
 
 				node.setFocus(true);
 				node.setActive(true);
@@ -56,7 +56,7 @@
 		name: "contextMenu",
 		version: "1.0",
 		contextMenu: {
-      selector: 'fancytree-title',
+      selector: "fancytree-title",
 			menu: {},
 			actions: {}
 		},


### PR DESCRIPTION
- bind context menu event to tree root element
- fix context menu bug when there is more than one tree in the same page
- adding `selector` option allowing user control the context menu bind element
