### PR TITLE
fix auto-scroll calculation

### DIFF
--- a/src/jquery.fancytree.js
+++ b/src/jquery.fancytree.js
@@ -1203,7 +1203,7 @@ FancytreeNode.prototype = /** @lends FancytreeNode# */{
 			if(topNode){
 				topNodeY = topNode ? $(topNode.span).position().top : 0;
 				if((nodeY - topNodeY) > containerHeight){
-					newScrollTop = scrollTop + nodeY;
+					newScrollTop = scrollTop + topNodeY;
 				}
 			}
 		}


### PR DESCRIPTION
When the child nodes of a node exceed the container height, the top node should stay in view.
