### PR TITLE
Allow modification of node title in *beforeEdit* callback

### DIFF
--- a/src/jquery.fancytree.edit.js
+++ b/src/jquery.fancytree.edit.js
@@ -74,6 +74,9 @@ $.ui.fancytree._FancytreeNodeClass.prototype.editStart = function(){
 	if( instOpts.beforeEdit.call(node, {type: "beforeEdit"}, eventData) === false){
 		return false;
 	}
+	// beforeEdit may want to modify the title before editing
+	prevTitle = node.title;
+
 	node.debug("editStart");
 	// Disable standard Fancytree mouse- and key handling
 	tree.widget._unbind();


### PR DESCRIPTION
If the input value is changed in _edit_ callback, the cursor ends up at the end of the text.

Being able to change the node title in _beforeEdit_ avoids this.
Changing the input value in _edit_ also breaks detection of modification.

My use case is, that I display more information, than should be editable, e.g.:

```
Standard-Kettengehänge in Güteklasse 8 | 30* | (37) | [138]
```

for editing, only:

```
Standard-Kettengehänge in Güteklasse 8 | 30*
```

should be available.
