### PR TITLE
Fix handling of double click in edit extension

### DIFF
--- a/src/jquery.fancytree.edit.js
+++ b/src/jquery.fancytree.edit.js
@@ -291,8 +291,9 @@ $.ui.fancytree.registerExtension({
 	nodeDblclick: function(ctx) {
 		if( $.inArray("dblclick", ctx.options.edit.triggerStart) >= 0 ){
 			ctx.node.editStart();
+			return false;
 		}
-		return false;
+		return this._super(ctx);
 	},
 	nodeKeydown: function(ctx) {
 		switch( ctx.originalEvent.which ) {


### PR DESCRIPTION
I like to keep double click for expanding/collapsing nodes.

Currently the edit extension prevents the double click event, even if it
is not in option _triggerStart_.
