### PR TITLE
nodeRemoveChildren() don't collapse node

### DIFF
--- a/src/jquery.fancytree.js
+++ b/src/jquery.fancytree.js
@@ -1260,7 +1260,8 @@ FancytreeNode.prototype = /** @lends FancytreeNode# */{
 	 * event is triggered on next expand.
 	 */
 	resetLazy: function() {
-		this.removeChildren(); // also collapses
+		this.removeChildren();
+		this.expanded = false;
 		this.lazy = true;
 		this.children = undefined;
 		this.renderStatus();


### PR DESCRIPTION
I have a command that programmatically replaces all child nodes of some tree node (by `removeChildren()`/`addChildren()`). With new version of Fancytree parent node is always collapsed after executing this command. The reason is that `nodeRemoveChildren()` explicitly reset `expanded` flag. I think it's wrong. It's more logically to explicitly set `expanded` as true, because there are no child nodes and they don't keep any space. But I suppose that the most correct way is don't change `expanded` flag at all.
