### PR TITLE
table-ext: children are not displayed when filtering

### DIFF
--- a/src/jquery.fancytree.table.js
+++ b/src/jquery.fancytree.table.js
@@ -35,9 +35,9 @@ function insertSiblingAfter(referenceNode, newNode) {
 function setChildRowVisibility(parent, flag) {
 	parent.visit(function(node){
 		var tr = node.tr;
-		flag = node.hide ? false : flag; // fix for ext-filter
+		currentFlag = node.hide ? false : flag; // fix for ext-filter
 		if(tr){
-			tr.style.display = flag ? "" : "none";
+			tr.style.display = currentFlag ? "" : "none";
 		}
 		if(!node.expanded){
 			return "skip";


### PR DESCRIPTION
flag variable is override to false when node is hidden when doing 
flag = node.hide ? false : flag 
so if the the first node is hidden all following nodes are set to false.
