### PR TITLE
Render noExpander icon from icon map for leaf nodes

### DIFF
--- a/src/jquery.fancytree.glyph.js
+++ b/src/jquery.fancytree.glyph.js
@@ -82,8 +82,10 @@ $.ui.fancytree.registerExtension({
 				icon = "expanderOpen";
 			}else if( node.isUndefined() ){
 				icon = "expanderLazy";
-			}else{
+			}else if( node.hasChildren() ){
 				icon = "expanderClosed";
+			}else{
+				icon = "noExpander";
 			}
 			span.className = "fancytree-expander " + map[icon];
 		}


### PR DESCRIPTION
I'm making this PR to highlight a feature request (no expander icons on leaf nodes), and to propose one limited solution for my specific use-case.

This is not the right answer and **should not be merged**: it works for FontAwesome where the .fa class is a good way to get an empty space. I don't know whether glyphicons has anything similar. And this patch doesn't solve the problem for non-glyph rendering where an empty image is probably required.

For reference, this patch requires this as part of a fontawesome config for the glyph extension: `glyph:{map:{noExpander:"fa"}}`
