### PR TITLE
Do not show an error if the node have no children

### DIFF
--- a/src/jquery.fancytree.js
+++ b/src/jquery.fancytree.js
@@ -339,8 +339,11 @@ FancytreeNode.prototype = /** @lends FancytreeNode# */{
 		if(!this.children){
 			this.children = [];
 		}
-		for(i=0, l=children.length; i<l; i++){
-			nodeList.push(new FancytreeNode(this, children[i]));
+		if (children)
+		{
+			for(i=0, l=children.length; i<l; i++){
+				nodeList.push(new FancytreeNode(this, children[i]));
+			}
 		}
 		firstNode = nodeList[0];
 		if(insertBefore == null){


### PR DESCRIPTION
In case of custorm lazyLoad, if the node have no children, and if the node is activated, Javascript show an error because the length can not be found on an undefined object.
This prevent javascript to fire this error.
