### PR TITLE
Generate form elements with same name attribute

### DIFF
--- a/src/jquery.fancytree.js
+++ b/src/jquery.fancytree.js
@@ -1883,7 +1883,7 @@ Fancytree.prototype = /** @lends Fancytree# */{
 	generateFormElements: function(selected, active) {
 		// TODO: test case
 		var nodeList,
-			selectedName = (selected !== false) ? "ft_" + this._id : selected,
+			selectedName = (selected !== false) ? "ft_" + this._id + "[]" : selected,
 			activeName = (active !== false) ? "ft_" + this._id + "_active" : active,
 			id = "fancytree_result_" + this._id,
 			$result = this.$container.find("div#" + id);


### PR DESCRIPTION
Issue :
Fancytree Options: checkbox = true 

When fancytree embed in form and select one or more node from tree, it is generated form elements with the same name attribute. Please see the below
<_input type="checkbox" name="ft_1" value="node1" checked="checked">
<_input type="checkbox" name="ft_1" value="node3" checked="checked">

This causes that when the form post to the server, there is one value in $_POST global variable.
Solution :
If we change it's name attribute to "ft_1[]", all values are in array called "ft_1" in $_POST
