### PR TITLE
this commit fixes #246

### DIFF
--- a/src/skin-awesome/ui.fancytree.css
+++ b/src/skin-awesome/ui.fancytree.css
@@ -47,7 +47,6 @@ ul.fancytree-container li {
   background-repeat: repeat-y;
   background-image: none;
   margin: 0;
-  padding: 1px 0 0 0;
 }
 ul.fancytree-container li.fancytree-lastsib {
   background-image: none;
@@ -241,7 +240,6 @@ table.fancytree-ext-columnview tbody tr td > ul li {
   background-image: none;
   /* no v-lines */
   margin: 0;
-  padding: 1px 0 0 0;
 }
 table.fancytree-ext-columnview span.fancytree-node {
   position: relative;

--- a/src/skin-bootstrap/ui.fancytree.css
+++ b/src/skin-bootstrap/ui.fancytree.css
@@ -47,7 +47,6 @@ ul.fancytree-container li {
   background-repeat: repeat-y;
   background-image: none;
   margin: 0;
-  padding: 1px 0 0 0;
 }
 ul.fancytree-container li.fancytree-lastsib {
   background-image: none;
@@ -241,7 +240,6 @@ table.fancytree-ext-columnview tbody tr td > ul li {
   background-image: none;
   /* no v-lines */
   margin: 0;
-  padding: 1px 0 0 0;
 }
 table.fancytree-ext-columnview span.fancytree-node {
   position: relative;

--- a/src/skin-common.less
+++ b/src/skin-common.less
@@ -118,7 +118,6 @@ ul.fancytree-container {
 		background-image: none;  // no v-lines
 
 		margin: 0;
-		padding: 1px 0 0 0;
 	}
 	// Suppress lines for last child node
 	li.fancytree-lastsib {
@@ -533,7 +532,6 @@ table.fancytree-ext-columnview {
 				background-image: none;  /* no v-lines */
 
 				margin: 0;
-				padding: 1px 0 0 0;
 			}
 		}
 	}

--- a/src/skin-lion/ui.fancytree.css
+++ b/src/skin-lion/ui.fancytree.css
@@ -53,7 +53,6 @@ ul.fancytree-container li {
   background-repeat: repeat-y;
   background-image: none;
   margin: 0;
-  padding: 1px 0 0 0;
 }
 ul.fancytree-container li.fancytree-lastsib {
   background-image: none;
@@ -382,7 +381,6 @@ table.fancytree-ext-columnview tbody tr td > ul li {
   background-image: none;
   /* no v-lines */
   margin: 0;
-  padding: 1px 0 0 0;
 }
 table.fancytree-ext-columnview span.fancytree-node {
   position: relative;

--- a/src/skin-themeroller/ui.fancytree.css
+++ b/src/skin-themeroller/ui.fancytree.css
@@ -357,7 +357,6 @@ table.fancytree-ext-columnview td >ul li
 	background-image: none;  /* no v-lines */
 
 	margin: 0;
-	padding: 1px 0 0 0;
 }
 /*
 table.fancytree-ext-columnview tbody tr[0] {

--- a/src/skin-vista/ui.fancytree.css
+++ b/src/skin-vista/ui.fancytree.css
@@ -63,7 +63,6 @@ ul.fancytree-container li {
   background-repeat: repeat-y;
   background-image: none;
   margin: 0;
-  padding: 1px 0 0 0;
 }
 ul.fancytree-container li.fancytree-lastsib {
   background-image: none;
@@ -392,7 +391,6 @@ table.fancytree-ext-columnview tbody tr td > ul li {
   background-image: none;
   /* no v-lines */
   margin: 0;
-  padding: 1px 0 0 0;
 }
 table.fancytree-ext-columnview span.fancytree-node {
   position: relative;

--- a/src/skin-win7/ui.fancytree.css
+++ b/src/skin-win7/ui.fancytree.css
@@ -47,7 +47,6 @@ ul.fancytree-container li {
   background-repeat: repeat-y;
   background-image: none;
   margin: 0;
-  padding: 1px 0 0 0;
 }
 ul.fancytree-container li.fancytree-lastsib {
   background-image: none;
@@ -376,7 +375,6 @@ table.fancytree-ext-columnview tbody tr td > ul li {
   background-image: none;
   /* no v-lines */
   margin: 0;
-  padding: 1px 0 0 0;
 }
 table.fancytree-ext-columnview span.fancytree-node {
   position: relative;

--- a/src/skin-win8-xxl/ui.fancytree.css
+++ b/src/skin-win8-xxl/ui.fancytree.css
@@ -47,7 +47,6 @@ ul.fancytree-container li {
   background-repeat: repeat-y;
   background-image: none;
   margin: 0;
-  padding: 1px 0 0 0;
 }
 ul.fancytree-container li.fancytree-lastsib {
   background-image: none;
@@ -376,7 +375,6 @@ table.fancytree-ext-columnview tbody tr td > ul li {
   background-image: none;
   /* no v-lines */
   margin: 0;
-  padding: 1px 0 0 0;
 }
 table.fancytree-ext-columnview span.fancytree-node {
   position: relative;

--- a/src/skin-win8/ui.fancytree.css
+++ b/src/skin-win8/ui.fancytree.css
@@ -47,7 +47,6 @@ ul.fancytree-container li {
   background-repeat: repeat-y;
   background-image: none;
   margin: 0;
-  padding: 1px 0 0 0;
 }
 ul.fancytree-container li.fancytree-lastsib {
   background-image: none;
@@ -376,7 +375,6 @@ table.fancytree-ext-columnview tbody tr td > ul li {
   background-image: none;
   /* no v-lines */
   margin: 0;
-  padding: 1px 0 0 0;
 }
 table.fancytree-ext-columnview span.fancytree-node {
   position: relative;

--- a/src/skin-xp/ui.fancytree.css
+++ b/src/skin-xp/ui.fancytree.css
@@ -47,7 +47,6 @@ ul.fancytree-container li {
   background-repeat: repeat-y;
   background-image: none;
   margin: 0;
-  padding: 1px 0 0 0;
 }
 ul.fancytree-container li.fancytree-lastsib {
   background-image: none;
@@ -375,7 +374,6 @@ table.fancytree-ext-columnview tbody tr td > ul li {
   background-image: none;
   /* no v-lines */
   margin: 0;
-  padding: 1px 0 0 0;
 }
 table.fancytree-ext-columnview span.fancytree-node {
   position: relative;


### PR DESCRIPTION
Padding for "ul.fancytree-container li" is set to "1px 0 0 0" which
doesn't seem to serve any purpose and creates gaps between nodes when
filtering in "hide" mode.  This takes out the padding

<!---
@huboard:{"order":93.5,"custom_state":""}
-->
