### PR TITLE
Update jquery.fancytree.edit.js - pressing `Del` during node edit causes node to be deleted.

### DIFF
--- a/src/jquery.fancytree.edit.js
+++ b/src/jquery.fancytree.edit.js
@@ -117,6 +117,7 @@ $.ui.fancytree._FancytreeNodeClass.prototype.editStart = function(){
 				node.editEnd(true, event);
 				return false; // so we don't start editmode on Mac
 			}
+			event.stopPropagation();
 		}).blur(function(event){
 			return node.editEnd(true, event);
 		});


### PR DESCRIPTION
While node is in edit mode, typing the "Del" key during edit will cause the row to be deleted by the tree.
This edit swallows keydown events inside the input control and does not allow them to propagate to parent elements.
Fixes issue #275 
