### PR TITLE
Node icons are customizable in glyph extension

### DIFF
--- a/src/jquery.fancytree.glyph.js
+++ b/src/jquery.fancytree.glyph.js
@@ -103,11 +103,15 @@ $.ui.fancytree.registerExtension({
 		// span = $("span.fancytree-icon", node.span).get(0);
 		span = $span.children("span.fancytree-icon").get(0);
 		if( span ){
-			if( node.folder ){
-				icon = node.expanded ? _getIcon(opts, "folderOpen") : _getIcon(opts, "folder");
-			}else{
-				icon = node.expanded ? _getIcon(opts, "docOpen") : _getIcon(opts, "doc");
-			}
+			if ( node.data && node.data.type ){
+                    		icon = _getIcon(opts, node.data.type);
+                	}else{
+				if( node.folder ){
+					icon = node.expanded ? _getIcon(opts, "folderOpen") : _getIcon(opts, "folder");
+				}else{
+					icon = node.expanded ? _getIcon(opts, "docOpen") : _getIcon(opts, "doc");
+				}
+                	}
 			span.className = "fancytree-icon " + icon;
 		}
 	},


### PR DESCRIPTION
When using the glyph extension the node icons are customizable by setting the 'type' property on a node and defining the mapping in the glyph extension configuration
