### PR TITLE
Check if the user is using icons or checkboxes

### DIFF
--- a/src/jquery.fancytree.wide.js
+++ b/src/jquery.fancytree.wide.js
@@ -143,7 +143,7 @@ $.ui.fancytree.registerExtension({
 		}
 		this._local.measureUnit = iconWidthUnit;
 		this._local.levelOfs = parseFloat(levelOfs);
-		this._local.lineOfs = (ctx.options.checkbox ? 3 : 2) * (iconWidth + iconSpacing) + iconSpacing;
+		this._local.lineOfs = (1 + (ctx.options.checkbox ? 1 : 0) + (ctx.options.icons ? 1 : 0)) * (iconWidth + iconSpacing) + iconSpacing;
 		this._local.maxDepth = 10;
 
 		// Get/Set a unique Id on the container (if not already exists)


### PR DESCRIPTION
The old version only checked for checkboxes, so if the user had icons disabled it would mess up formatting. This commit fixes that.