### PR TITLE
ExtPersist beforeRestore event

### DIFF
--- a/src/jquery.fancytree.persist.js
+++ b/src/jquery.fancytree.persist.js
@@ -238,7 +238,7 @@ $.ui.fancytree.registerExtension({
 			if ( !tree._triggerTreeEvent("beforeRestore", null, {}) ) {
 				return;
 			}
-			
+
 			var cookie, dfd, i, keyList, node,
 				prevFocus = local._data(local.cookiePrefix + FOCUS), // record this before node.setActive() overrides it;
 				noEvents = instOpts.fireActivate === false;

--- a/src/jquery.fancytree.persist.js
+++ b/src/jquery.fancytree.persist.js
@@ -235,6 +235,8 @@ $.ui.fancytree.registerExtension({
 
 		// Bind init-handler to apply cookie state
 		tree.$div.bind("fancytreeinit", function(event){
+			if (!tree._triggerTreeEvent("beforeRestore", null, {})) return;
+			
 			var cookie, dfd, i, keyList, node,
 				prevFocus = local._data(local.cookiePrefix + FOCUS), // record this before node.setActive() overrides it;
 				noEvents = instOpts.fireActivate === false;

--- a/src/jquery.fancytree.persist.js
+++ b/src/jquery.fancytree.persist.js
@@ -235,7 +235,9 @@ $.ui.fancytree.registerExtension({
 
 		// Bind init-handler to apply cookie state
 		tree.$div.bind("fancytreeinit", function(event){
-			if (!tree._triggerTreeEvent("beforeRestore", null, {})) return;
+			if ( !tree._triggerTreeEvent("beforeRestore", null, {}) ) {
+				return;
+			}
 			
 			var cookie, dfd, i, keyList, node,
 				prevFocus = local._data(local.cookiePrefix + FOCUS), // record this before node.setActive() overrides it;


### PR DESCRIPTION
Hello there,
I've added a beforeRestore event being fired before the tree status is restored by ExtPersist.
The callback function is passed just like with the restore event, and it may return false to prevent tree state restoration.
If you find this useful, please accept the pull request and merge the code at your convenience.

This should not break any demos, you decide if a new demo is needed.
I suggest to update the wiki and the documentation, feel free to ask if I could be of any help.

Cheers!
