### PR TITLE
Fix jsdoc, Class: Fancytree, Methods: void clear()

### DIFF
--- a/src/jquery.fancytree.js
+++ b/src/jquery.fancytree.js
@@ -2123,7 +2123,7 @@ Fancytree.prototype = /** @lends Fancytree# */{
 		}
 	},
    */
-	/** Remove alle nodes.
+	/** Remove all nodes.
 	 * @since 2.14
 	 */
 	clear: function(source) {


### PR DESCRIPTION
Hello,

This javascript library is great. I read the js doc, but I saw a mistake.
There was a german word instead of a english word. 

I hope to contribute more, for the next time.