### PR TITLE
Keyboard navigation and autoScroll

### DIFF
--- a/demo/sample-scroll.html
+++ b/demo/sample-scroll.html
@@ -70,9 +70,6 @@ $.fn.scrollTo = function( target, options, callback ){
 			init: function(event, data) {
 				data.tree.getFirstChild().setFocus();
 			},
-			focus: function(event, data){
-				data.node.scrollIntoView(true);
-			},
 			// expand: function(event, data){
 			// 	// scroll down to last node, but keep current node visible
 			// 	data.node.getLastChild().scrollIntoView(true, {topNode: data.node});

--- a/src/jquery.fancytree.js
+++ b/src/jquery.fancytree.js
@@ -1386,7 +1386,8 @@ FancytreeNode.prototype = /** @lends FancytreeNode# */{
 		// Navigate to node
 		function _goto(n){
 			if( n ){
-				try { n.makeVisible(); } catch(e) {} // #272
+				// setFocus/setActive will scroll later (if autoScroll is specified)
+				try { n.makeVisible({scrollIntoView: false}); } catch(e) {} // #272
 				// Node may still be hidden by a filter
 				if( ! $(n.span).is(":visible") ) {
 					n.debug("Navigate: skipping hidden node");


### PR DESCRIPTION
The core of the keyboard navigation is `navigate` method. It calls `makeVisible` and then `setFocus`/`setActive`. `makeVisible` calls `scrollIntoView` in its turn. But if option `autoScroll` is specified `setFocus` and `setActive` also call `scrollIntoView`. So scrolling runs two times. Look at the `sample-scroll.html` (before this PR). You can see that the tree shakes a little while scrolling with a keyboard.

Also I suppose that keyboard navigation should take into account `autoScroll` option. When `autoScroll` is off keyboard navigation must not scroll the tree. Now it always scroll. I handle `activate` event, execute some custom logic there and then call `scrollIntoView` explicitly. But keyboard navigation scrolls extra time and I can't turn it off.

So I propose to call `makeVisible({scrollIntoView: false})` in `navigate` method. If `autoScroll` is true, `setFocus`/`setActive` will scroll later.
