### PR TITLE
fix mode3 error with unselectable elements

### DIFF
--- a/src/jquery.fancytree.js
+++ b/src/jquery.fancytree.js
@@ -673,29 +673,32 @@ FancytreeNode.prototype = /** @lends FancytreeNode# */{
 	_changeSelectStatusAttrs: function (state) {
 		var changed = false;
 
-		switch(state){
-		case false:
-			changed = ( this.selected || this.partsel );
-			this.selected = false;
-			this.partsel = false;
-			break;
-		case true:
-			changed = ( !this.selected || !this.partsel );
-			this.selected = true;
-			this.partsel = true;
-			break;
-		case undefined:
-			changed = ( this.selected || !this.partsel );
-			this.selected = false;
-			this.partsel = true;
-			break;
-		default:
-			_assert(false, "invalid state: " + state);
-		}
-		// this.debug("fixSelection3AfterLoad() _changeSelectStatusAttrs()", state, changed);
-		if( changed ){
-			this.renderStatus();
-		}
+                if(this.unselectable == undefined || !this.unselectable) {
+
+                    switch(state){
+                    case false:
+                            changed = ( this.selected || this.partsel );
+                            this.selected = false;
+                            this.partsel = false;
+                            break;
+                    case true:
+                            changed = ( !this.selected || !this.partsel );
+                            this.selected = true;
+                            this.partsel = true;
+                            break;
+                    case undefined:
+                            changed = ( this.selected || !this.partsel );
+                            this.selected = false;
+                            this.partsel = true;
+                            break;
+                    default:
+                            _assert(false, "invalid state: " + state);
+                    }
+                    // this.debug("fixSelection3AfterLoad() _changeSelectStatusAttrs()", state, changed);
+                    if( changed ){
+                            this.renderStatus();
+                    }
+                }
 		return changed;
 	},
 	/**

--- a/src/jquery.fancytree.js
+++ b/src/jquery.fancytree.js
@@ -673,7 +673,7 @@ FancytreeNode.prototype = /** @lends FancytreeNode# */{
 	_changeSelectStatusAttrs: function (state) {
 		var changed = false;
 
-                if(this.unselectable == undefined || !this.unselectable) {
+                if(this.unselectable === undefined || !this.unselectable) {
 
                     switch(state){
                     case false:


### PR DESCRIPTION
My problem was that when I selected a paren, this event changed the state of every child node, included every disabled child node.

I want to preserve the state checked/unchecked of every disabled child node.