### PR TITLE
jquery.fancytree.glyph: robust loading state handling, do not update class in case of empty options

### DIFF
--- a/src/jquery.fancytree.glyph.js
+++ b/src/jquery.fancytree.glyph.js
@@ -86,9 +86,12 @@ $.ui.fancytree.registerExtension({
 			if( node.isLoading() ) {
 				// NOTE: it's important to handle "loading" as nodeRenderStatus can be called w/o nodeSetStatus
 				icon = "loading";
-			}else if( node.expanded && node.hasChildren() ){
+			}else if( node.expanded && node.children.length  /*node.hasChildren()*/ ){
+				// node can has a fake "loading" or "error" child node (so usually hasChildren() should be used to filter this cases out)
+				// But here we don't care what these nodes are, it's something below the current node and it's expanded
 				icon = "expanderOpen";
 			}else if( node.isUndefined() ){
+				// unknown yet do children exist or not
 				icon = "expanderLazy";
 			}else if( node.hasChildren() ){
 				icon = "expanderClosed";

--- a/src/jquery.fancytree.glyph.js
+++ b/src/jquery.fancytree.glyph.js
@@ -19,11 +19,11 @@
 
 function hasStdIcons(opts) {
 	var map = opts.map;
-	return map["doc"] || map["docOpen"] || map["folder"] || map["folderOpen"];
+	return map.doc || map.docOpen || map.folder || map.folderOpen;
 }
 function hasCheckboxIcons(opts) {
 	var map = opts.map;
-	return map["checkbox"] || map["checkboxSelected"] || map["checkboxUnknown"];
+	return map.checkbox || map.checkboxSelected || map.checkboxUnknown;
 }
 
 $.ui.fancytree.registerExtension({


### PR DESCRIPTION
* added: checkbox/std icons now optional (do not overwrite className if classes are empty in optons)
* added: handling `node.isLoading` in nodeRenderStatus (it's important as nodeRenderStatus can be called w/o nodeSetStatus)
* tiny: usage of deprecated isRoot is replace with isRootNode
* tiny: removed _getIcon