### PR TITLE
ext-dnd: options for drop marker offset

### DIFF
--- a/src/jquery.fancytree.dnd.js
+++ b/src/jquery.fancytree.dnd.js
@@ -258,9 +258,8 @@ $.ui.fancytree.registerExtension({
 		preventVoidMoves: true, 	// Prevent dropping nodes 'before self', etc.
 		preventRecursiveMoves: true,// Prevent dropping nodes on own descendants
 		smartRevert: true,   // set draggable.revert = true if drop was rejected
-		dropMarkerOffset: -24,		// absolute position offset for .fancytree-drop-marker relatively to ..fancytree-title (icon/img near a node accepting drop)
-		dropMarkerOffsetBefore: -16,	// additional offset for drop-marker with hitMode="before"
-		dropMarkerOffsetAfter: -16,	// additional offset for drop-marker with hitMode="after"
+		dropMarkerOffsetX: -24,			// absolute position offset for .fancytree-drop-marker relatively to ..fancytree-title (icon/img near a node accepting drop)
+		dropMarkerInsertOffsetX: -16,	// additional offset for drop-marker with hitMode = "before"/"after"
 		// Events (drag support)
 		dragStart: null,     // Callback(sourceNode, data), return true, to enable dnd
 		dragStop: null,      // Callback(sourceNode, data)
@@ -323,15 +322,15 @@ $.ui.fancytree.registerExtension({
 			}
 		}
 		if( hitMode === "after" || hitMode === "before" || hitMode === "over" ){
-			markerOffsetX = dndOpt.dropMarkerOffset || 0;
+			markerOffsetX = dndOpt.dropMarkerOffsetX || 0;
 			switch(hitMode){
 			case "before":
 				markerAt = "top";
-				markerOffsetX += (dndOpt.dropMarkerOffsetBefore || 0);
+				markerOffsetX += (dndOpt.dropMarkerInsertOffsetX || 0);
 				break;
 			case "after":
 				markerAt = "bottom";
-				markerOffsetX += (dndOpt.dropMarkerOffsetAfter || 0);
+				markerOffsetX += (dndOpt.dropMarkerInsertOffsetX || 0);
 				break;
 			}
 

--- a/src/jquery.fancytree.dnd.js
+++ b/src/jquery.fancytree.dnd.js
@@ -255,9 +255,12 @@ $.ui.fancytree.registerExtension({
 		draggable: null,     // Additional options passed to jQuery draggable
 		droppable: null,     // Additional options passed to jQuery droppable
 		focusOnClick: false, // Focus, although draggable cancels mousedown event (#270)
-		preventVoidMoves: true, // Prevent dropping nodes 'before self', etc.
-		preventRecursiveMoves: true, // Prevent dropping nodes on own descendants
+		preventVoidMoves: true, 	// Prevent dropping nodes 'before self', etc.
+		preventRecursiveMoves: true,// Prevent dropping nodes on own descendants
 		smartRevert: true,   // set draggable.revert = true if drop was rejected
+		dropMarkerOffset: -24,		// absolute position offset for .fancytree-drop-marker relatively to ..fancytree-title (icon/img near a node accepting drop)
+		dropMarkerOffsetBefore: -16,	// additional offset for drop-marker with hitMode="before"
+		dropMarkerOffsetAfter: -16,	// additional offset for drop-marker with hitMode="after"
 		// Events (drag support)
 		dragStart: null,     // Callback(sourceNode, data), return true, to enable dnd
 		dragStop: null,      // Callback(sourceNode, data)
@@ -300,7 +303,8 @@ $.ui.fancytree.registerExtension({
 		var markerOffsetX,
 			markerAt = "center",
 			instData = this._local,
-			glyph = this.options.glyph || null,
+			dndOpt = this.options.dnd ,
+			glyphOpt = this.options.glyph,
 			$source = sourceNode ? $(sourceNode.span) : null,
 			$target = $(targetNode.span),
 			$targetTitle = $target.find(">span.fancytree-title");
@@ -312,22 +316,22 @@ $.ui.fancytree.registerExtension({
 				.prependTo($(this.$div).parent());
 //                .prependTo("body");
 
-			if( glyph ) {
+			if( glyphOpt ) {
 				// instData.$dropMarker.addClass(glyph.map.dragHelper);
 				instData.$dropMarker
-					.addClass(glyph.map.dropMarker);
+					.addClass(glyphOpt.map.dropMarker);
 			}
 		}
 		if( hitMode === "after" || hitMode === "before" || hitMode === "over" ){
-			markerOffsetX = -24;
+			markerOffsetX = dndOpt.dropMarkerOffset || 0;
 			switch(hitMode){
 			case "before":
 				markerAt = "top";
-				markerOffsetX -= 16;
+				markerOffsetX += (dndOpt.dropMarkerOffsetBefore || 0);
 				break;
 			case "after":
 				markerAt = "bottom";
-				markerOffsetX -= 16;
+				markerOffsetX += (dndOpt.dropMarkerOffsetAfter || 0);
 				break;
 			}
 

--- a/src/jquery.fancytree.dnd5.js
+++ b/src/jquery.fancytree.dnd5.js
@@ -218,15 +218,15 @@ function handleDragOver(event, data) {
 	LAST_HIT_MODE = hitMode;
 	//
 	if( hitMode === "after" || hitMode === "before" || hitMode === "over" ){
-		markerOffsetX = -24;
+		markerOffsetX = dndOpts.dropMarkerOffsetX || 0;
 		switch(hitMode){
 		case "before":
 			markerAt = "top";
-			markerOffsetX -= 16;
+			markerOffsetX += (dndOpts.dropMarkerInsertOffsetX || 0);
 			break;
 		case "after":
 			markerAt = "bottom";
-			markerOffsetX -= 16;
+			markerOffsetX += (dndOpts.dropMarkerInsertOffsetX || 0);
 			break;
 		}
 
@@ -275,6 +275,8 @@ $.ui.fancytree.registerExtension({
 		scroll: true,                // Enable auto-scrolling while dragging
 		scrollSensitivity: 20,       // Active top/bottom margin in pixel
 		scrollSpeed: 5,              // Pixel per event
+		dropMarkerOffsetX: -24,		 // absolute position offset for .fancytree-drop-marker relatively to ..fancytree-title (icon/img near a node accepting drop)
+		dropMarkerInsertOffsetX: -16,// additional offset for drop-marker with hitMode = "before"/"after"
 		// Events (drag support)
 		dragStart: null,       // Callback(sourceNode, data), return true, to enable dnd drag
 		dragDrag: $.noop,      // Callback(sourceNode, data)


### PR DESCRIPTION
Hard-coded offset for drop marker was replaced by usage of values from extension's options (`dropMarkerOffset`/`dropMarkerOffsetBefore`/`dropMarkerOffsetAfter`).