### PR TITLE
Prevent default behavior on hot key combination

### DIFF
--- a/3rd-party/extensions/hotkeys/hotkeys.html
+++ b/3rd-party/extensions/hotkeys/hotkeys.html
@@ -37,7 +37,15 @@
 				keydown: {
 					"shift+a": function(node) {
 						$("#selected-action").append(document.createTextNode("Key down 'Shift + a' on node " + node)).append("<br />");
+					}, 
+					'ctrl+d': function(node, evt) {
+						$('#selected-action').append(document.createTextNode('Key down "Ctrl + d" on node ' + node)).append('<br />');
+						var new_node = $.extend(node.toDict(), {key: new Date().getTime().toString()}); // timestamp for dummy key
+						node.appendSibling(new_node);
+						evt.stopPropagation();
+						return false;
 					}
+
 				},
 				keypress: {
 					"shift+a": function(node) {
@@ -77,7 +85,7 @@
 
 <hr />
 
-<div id="selected-action">Activate one node and click "Shift + a":<br /></div>
+<div id="selected-action">Activate one node and click "Shift + a" or "Ctrl + d":<br /></div>
 
 <!-- Start_Exclude: This block is not part of the sample code -->
 <hr>

--- a/3rd-party/extensions/hotkeys/js/jquery.fancytree.hotkeys.js
+++ b/3rd-party/extensions/hotkeys/js/jquery.fancytree.hotkeys.js
@@ -14,9 +14,11 @@
 	var initHotkeys = function(tree, data) {
 		$.each(data, function(event, keys) {
 			$.each(keys, function(key, handler) {
-				$(tree.$container).on(event, null, key, function() {
+				$(tree.$container).on(event, null, key, function(evt) {
 					var node = tree.getActiveNode();
 					handler(node);
+					evt.preventDefault();
+					evt.stopPropagation();
 				});
 			});
 		});

--- a/3rd-party/extensions/hotkeys/js/jquery.fancytree.hotkeys.js
+++ b/3rd-party/extensions/hotkeys/js/jquery.fancytree.hotkeys.js
@@ -16,9 +16,8 @@
 			$.each(keys, function(key, handler) {
 				$(tree.$container).on(event, null, key, function(evt) {
 					var node = tree.getActiveNode();
-					handler(node);
-					evt.preventDefault();
-					evt.stopPropagation();
+					return handler(node, evt);
+                    // return false from the handler will stop default handling.
 				});
 			});
 		});


### PR DESCRIPTION
Key combination stroke (like ctrl+d, ctrl+s) will trigger browser's default behavior which is expected to be prevented and because the event was already handled by Fancytree's hotkey plugin.