### PR TITLE
Fix DND where fancytree-title span is not a direct child due to custom layouts

### DIFF
--- a/src/jquery.fancytree.dnd.js
+++ b/src/jquery.fancytree.dnd.js
@@ -306,7 +306,7 @@ $.ui.fancytree.registerExtension({
 			glyphOpt = this.options.glyph,
 			$source = sourceNode ? $(sourceNode.span) : null,
 			$target = $(targetNode.span),
-			$targetTitle = $target.find(">span.fancytree-title");
+			$targetTitle = $target.find("span.fancytree-title");
 
 		if( !instData.$dropMarker ) {
 			instData.$dropMarker = $("<div id='fancytree-drop-marker'></div>")

--- a/src/jquery.fancytree.dnd5.js
+++ b/src/jquery.fancytree.dnd5.js
@@ -162,7 +162,7 @@ function handleDragOver(event, data) {
 		// glyph = options.glyph || null,
 		// $source = sourceNode ? $(sourceNode.span) : null,
 		$target = $(targetNode.span),
-		$targetTitle = $target.find(">span.fancytree-title");
+		$targetTitle = $target.find("span.fancytree-title");
 
 	if(DRAG_ENTER_RESPONSE === false){
 		tree.warn("Ignore dragover, since dragenter returned false");  //, event, data);


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/mar10/fancytree/commit/c250f700f5b978e8a640a6a4e18ff4c505591c9a where the DND stopped working when a custom layout is used, where the fancytree-title span is not a direct child of the targetNode.

Fixes https://github.com/mar10/fancytree/issues/705