### PR TITLE
Fix for issue #712: clicking in scrolled tree can lead to scroll to top

### DIFF
--- a/demo/sample-scroll.html
+++ b/demo/sample-scroll.html
@@ -66,10 +66,7 @@ $.fn.scrollTo = function( target, options, callback ){
 			},
 			lazyLoad: function(event, data) {
 				data.result = {url: "../test/unit/ajax-sub2.json"}
-			},
-			init: function(event, data) {
-				data.tree.getFirstChild().setFocus();
-			},
+			}
 			// expand: function(event, data){
 			// 	// scroll down to last node, but keep current node visible
 			// 	data.node.getLastChild().scrollIntoView(true, {topNode: data.node});

--- a/test/unit/test-core.js
+++ b/test/unit/test-core.js
@@ -644,7 +644,7 @@ QUnit.test("makeVisible not rendered deep node", function(assert) {
  */
 QUnit.module("events");
 
-QUnit.test(".click() to expand a folder", function(assert) {
+QUnit.test(".mousedown() to expand a folder", function(assert) {
 	tools.setup(assert);
 	assert.expect(8);
 
@@ -667,11 +667,11 @@ QUnit.test(".click() to expand a folder", function(assert) {
 			done();
 		}
 	});
-	$("#tree #ft_10 span.fancytree-expander").click();
+	$("#tree #ft_10 span.fancytree-expander").mousedown();
 });
 
 
-QUnit.test(".click() to activate a node", function(assert) {
+QUnit.test(".mousedown() to activate a node", function(assert) {
 	tools.setup(assert);
 	assert.expect(8);
 
@@ -694,11 +694,11 @@ QUnit.test(".click() to activate a node", function(assert) {
 			done();
 		}
 	});
-	$("#tree #ft_2 span.fancytree-title").click();
+	$("#tree #ft_2 span.fancytree-title").mousedown();
 });
 
 
-QUnit.test(".click() to activate a folder (clickFolderMode 3 triggers expand)", function(assert) {
+QUnit.test(".mousedown() to activate a folder (clickFolderMode 3 triggers expand)", function(assert) {
 	tools.setup(assert);
 	assert.expect(4);
 
@@ -723,11 +723,11 @@ QUnit.test(".click() to activate a folder (clickFolderMode 3 triggers expand)", 
 			done();
 		}
 	});
-	$("#tree #ft_10 span.fancytree-title").click();
+	$("#tree #ft_10 span.fancytree-title").mousedown();
 });
 
 
-QUnit.test(".click() to select a node", function(assert) {
+QUnit.test(".mousedown() to select a node", function(assert) {
 	tools.setup(assert);
 	assert.expect(8);
 
@@ -751,7 +751,7 @@ QUnit.test(".click() to select a node", function(assert) {
 			done();
 		}
 	});
-	$("#tree #ft_2 span.fancytree-checkbox").click();
+	$("#tree #ft_2 span.fancytree-checkbox").mousedown();
 });
 
 
@@ -948,7 +948,7 @@ QUnit.test("selectMode: 3", function(assert) {
  */
 QUnit.module("lazy loading");
 
-QUnit.test("Using ajax options for `source`; .click() expands a lazy folder", function(assert) {
+QUnit.test("Using ajax options for `source`; .mousedown() expands a lazy folder", function(assert) {
 	tools.setup(assert);
 	assert.expect(19);
 
@@ -965,7 +965,7 @@ QUnit.test("Using ajax options for `source`; .click() expands a lazy folder", fu
 			assert.equal($("#tree li").length, TESTDATA_VISIBLENODES, "lazy tree has rendered 13 node elements");
 			// now expand a lazy folder
 			isClicked = true;
-			$("#tree #ft_30 span.fancytree-expander").click();
+			$("#tree #ft_30 span.fancytree-expander").mousedown();
 		},
 		beforeExpand: function(event, data){
 			assert.equal(sequence++, 4, "receive `beforeExpand` callback");
@@ -1005,7 +1005,7 @@ QUnit.test("Using ajax options for `source`; .click() expands a lazy folder", fu
 	});
 });
 
-QUnit.test("Using $.ajax promise for `source`; .click() expands a lazy folder", function(assert) {
+QUnit.test("Using $.ajax promise for `source`; .mousedown() expands a lazy folder", function(assert) {
 	tools.setup(assert);
 	assert.expect(12);
 
@@ -1025,7 +1025,7 @@ QUnit.test("Using $.ajax promise for `source`; .click() expands a lazy folder", 
 			assert.equal($("#tree li").length, TESTDATA_VISIBLENODES, "lazy tree has rendered 13 node elements");
 			// now expand a lazy folder
 			isClicked = true;
-			$("#tree #ft_30 span.fancytree-expander").click();
+			$("#tree #ft_30 span.fancytree-expander").mousedown();
 		},
 		beforeExpand: function(event, data){
 			assert.equal(sequence++, 3, "receive `beforeExpand` callback");


### PR DESCRIPTION
Ensure tree item is focused *after* mouse click has had a chance to set focus.

Currently treeSetFocus will focus the first tree item if nothing else had focus.
However, a mouse click does not have a chance to set focus until after the
mouse is released. In order for the treeSetFocus to know that something
was focused with the mouse, we need to:
1) Set focus on a tree item immediately on a mousedown
2) Use a setTimeout(ensureFocus, 0) in treeSetFocus to ensure that
   it runs after the mousedown handler

This prevents the tree from scrolling back up when the user clicks in it.