### PR TITLE
Fix webpack errors

### DIFF
--- a/dist/skin-awesome/ui.fancytree.less
+++ b/dist/skin-awesome/ui.fancytree.less
@@ -5,6 +5,8 @@
  * the LESS templates.
  */
 
+@fancy-image-dir:'./skin-awesome';
+
 // Import common styles
 @import "../skin-common.less";
 

--- a/dist/skin-bootstrap-n/ui.fancytree.less
+++ b/dist/skin-bootstrap-n/ui.fancytree.less
@@ -4,6 +4,8 @@
  * DON'T EDIT THE CSS FILE DIRECTLY, since it is automatically generated from
  * the LESS templates.
  */
+ 
+@fancy-image-dir:'./skin-bootstrap-n';
 
 // Import common styles
 @import "../skin-common.less";

--- a/dist/skin-bootstrap/ui.fancytree.less
+++ b/dist/skin-bootstrap/ui.fancytree.less
@@ -5,6 +5,8 @@
  * the LESS templates.
  */
 
+@fancy-image-dir:'./skin-bootstrap';
+
 // Import common styles
 @import "../skin-common.less";
 

--- a/dist/skin-common.less
+++ b/dist/skin-common.less
@@ -22,7 +22,6 @@
 
 // @fancy-line-ofs-top: (@fancy-line-height - @fancy-icon-height) / 2;
 
-@fancy-image-dir: ".";
 
 // Use 'url(...)' to link to the throbber image, or
 // use data-uri(...)' to inline the data in css instead:
@@ -560,7 +559,7 @@ span.fancytree-drop-reject {
 	span.fancytree-icon,
 	span.fancytree-drag-helper-img,
 	#fancytree-drop-marker {
-		background-image: url("icons-rtl.gif");
+		background-image: url("@{fancy-image-dir}/icons-rtl.gif");
 	}
 	.fancytree-exp-n span.fancytree-expander, 
 	.fancytree-exp-nl span.fancytree-expander {
@@ -568,7 +567,7 @@ span.fancytree-drop-reject {
 	}
 	&.fancytree-connectors .fancytree-exp-n span.fancytree-expander, 
 	&.fancytree-connectors .fancytree-exp-nl span.fancytree-expander {
-		background-image: url("icons-rtl.gif");
+		background-image: url("@{fancy-image-dir}/icons-rtl.gif");
 	}
 }
 ul.fancytree-container.fancytree-rtl {

--- a/dist/skin-lion/ui.fancytree.less
+++ b/dist/skin-lion/ui.fancytree.less
@@ -5,6 +5,8 @@
  * the LESS templates.
  */
 
+@fancy-image-dir:'./skin-lion';
+
 /*
  Lion colors:
 	gray highlight bar: #D4D4D4
@@ -32,7 +34,7 @@
 @fancy-icon-spacing: 3px;
 
 // Use 'data-uri(...)' to embed the image into CSS instead of linking to 'loading.gif':
-@fancy-loading-url: data-uri("@{fancy-image-dir}/loading.gif");
+@fancy-loading-url: data-uri("loading.gif");
 // Set to `true` to use `data-uri(...)` which will embed icons.gif into CSS 
 // instead of linking to that file:
 // @fancy-inline-sprites: true;

--- a/dist/skin-themeroller/ui.fancytree.less
+++ b/dist/skin-themeroller/ui.fancytree.less
@@ -7,6 +7,8 @@
  * the LESS templates.
  */
 
+@fancy-image-dir:'./skin-themeroller';
+
 // Import common styles
 @import "../skin-common.less";
 
@@ -36,7 +38,7 @@
 
 
 // Use 'data-uri(...)' to embed the image into CSS instead of linking to 'loading.gif':
-@fancy-loading-url: data-uri("@{fancy-image-dir}/loading.gif");
+@fancy-loading-url: data-uri("loading.gif");
 // Set to `true` to use `data-uri(...)` which will embed icons.gif into CSS 
 // instead of linking to that file:
 // @fancy-inline-sprites: true;

--- a/dist/skin-vista/ui.fancytree.less
+++ b/dist/skin-vista/ui.fancytree.less
@@ -5,6 +5,8 @@
  * the LESS templates.
  */
 
+@fancy-image-dir:'./skin-vista';
+
 /*
 both:
    unselected background: #FCFCFC 'nearly white'
@@ -44,7 +46,7 @@ List view:
 @fancy-icon-spacing: 3px;
 
 // Use 'data-uri(...)' to embed the image into CSS instead of linking to 'loading.gif':
-@fancy-loading-url: data-uri("@{fancy-image-dir}/loading.gif");
+@fancy-loading-url: data-uri("loading.gif");
 // Set to `true` to use `data-uri(...)` which will embed icons.gif into CSS 
 // instead of linking to that file:
 // @fancy-inline-sprites: true;

--- a/dist/skin-win7/ui.fancytree.less
+++ b/dist/skin-win7/ui.fancytree.less
@@ -5,6 +5,8 @@
  * the LESS templates.
  */
 
+@fancy-image-dir:'./skin-win7';
+
 // Fancytree Win7 styles
 
 // both: 
@@ -60,7 +62,7 @@
 @fancy-node-outline-width: 1px;
 
 // Use 'data-uri(...)' to embed the image into CSS instead of linking to 'loading.gif':
-@fancy-loading-url: data-uri("@{fancy-image-dir}/loading.gif");
+@fancy-loading-url: data-uri("loading.gif");
 // Set to `true` to use `data-uri(...)` which will embed icons.gif into CSS 
 // instead of linking to that file:
 // @fancy-inline-sprites: true;

--- a/dist/skin-win8-n/ui.fancytree.less
+++ b/dist/skin-win8-n/ui.fancytree.less
@@ -5,6 +5,8 @@
  * the LESS templates.
  */
 
+@fancy-image-dir:'./skin-win8-n';
+
 // Import common styles
 @import "../skin-common.less";
 
@@ -44,7 +46,7 @@
 @fancy-icon-spacing: 3px;
 
 // Use 'data-uri(...)' to embed the image into CSS instead of linking to 'loading.gif':
-@fancy-loading-url: data-uri("@{fancy-image-dir}/loading.gif");
+@fancy-loading-url: data-uri("loading.gif");
 // Set to `true` to use `data-uri(...)` which will embed icons.gif into CSS 
 // instead of linking to that file:
 // @fancy-inline-sprites: true;

--- a/dist/skin-win8-xxl/ui.fancytree.less
+++ b/dist/skin-win8-xxl/ui.fancytree.less
@@ -5,6 +5,8 @@
  * the LESS templates.
  */
 
+@fancy-image-dir:'./skin-win8-xxl';
+
 // Import common styles
 @import "../skin-common.less";
 

--- a/dist/skin-win8/ui.fancytree.less
+++ b/dist/skin-win8/ui.fancytree.less
@@ -5,6 +5,9 @@
  * the LESS templates.
  */
 
+@fancy-image-dir:'./';
+
+
 // Import common styles
 @import "../skin-common.less";
 
@@ -55,7 +58,7 @@
 // @fancy-icon-spacing: 3px;
 
 // Use 'data-uri(...)' to embed the image into CSS instead of linking to 'loading.gif':
-@fancy-loading-url: data-uri("@{fancy-image-dir}/loading.gif");
+@fancy-loading-url: data-uri("loading.gif");
 // Set to `true` to use `data-uri(...)` which will embed icons.gif into CSS 
 // instead of linking to that file:
 // @fancy-inline-sprites: true;

--- a/dist/skin-xp/ui.fancytree.less
+++ b/dist/skin-xp/ui.fancytree.less
@@ -5,6 +5,8 @@
  * the LESS templates.
  */
 
+@fancy-image-dir:'./skin-xp';
+
 // Import common styles
 @import "../skin-common.less";
 
@@ -26,7 +28,7 @@
 @fancy-node-border-width: 0;
 
 // Use 'data-uri(...)' to embed the image into CSS instead of linking to 'loading.gif':
-@fancy-loading-url: data-uri("@{fancy-image-dir}/loading.gif");
+@fancy-loading-url: data-uri("loading.gif");
 // Set to `true` to use `data-uri(...)` which will embed icons.gif into CSS 
 // instead of linking to that file:
 // @fancy-inline-sprites: true;
@@ -39,7 +41,7 @@ ul.fancytree-container {
 	li {
 		// background-image: url("vline.gif");
 		// Use 'data-uri(...)' to embed the image into CSS instead of linking to 'loading.gif':
-		background-image: data-uri("@{fancy-image-dir}/vline.gif");
+		background-image: data-uri("vline.gif");
 		background-position: 0 0;
 	}
 	&.fancytree-rtl {

--- a/src/skin-awesome/ui.fancytree.less
+++ b/src/skin-awesome/ui.fancytree.less
@@ -5,6 +5,8 @@
  * the LESS templates.
  */
 
+@fancy-image-dir:'./skin-awesome';
+
 // Import common styles
 @import "../skin-common.less";
 

--- a/src/skin-bootstrap-n/ui.fancytree.less
+++ b/src/skin-bootstrap-n/ui.fancytree.less
@@ -4,6 +4,8 @@
  * DON'T EDIT THE CSS FILE DIRECTLY, since it is automatically generated from
  * the LESS templates.
  */
+ 
+@fancy-image-dir:'./skin-bootstrap-n';
 
 // Import common styles
 @import "../skin-common.less";

--- a/src/skin-bootstrap/ui.fancytree.less
+++ b/src/skin-bootstrap/ui.fancytree.less
@@ -5,6 +5,8 @@
  * the LESS templates.
  */
 
+@fancy-image-dir:'./skin-bootstrap';
+
 // Import common styles
 @import "../skin-common.less";
 

--- a/src/skin-common.less
+++ b/src/skin-common.less
@@ -22,7 +22,6 @@
 
 // @fancy-line-ofs-top: (@fancy-line-height - @fancy-icon-height) / 2;
 
-@fancy-image-dir: ".";
 
 // Use 'url(...)' to link to the throbber image, or
 // use data-uri(...)' to inline the data in css instead:
@@ -560,7 +559,7 @@ span.fancytree-drop-reject {
 	span.fancytree-icon,
 	span.fancytree-drag-helper-img,
 	#fancytree-drop-marker {
-		background-image: url("icons-rtl.gif");
+		background-image: url("@{fancy-image-dir}/icons-rtl.gif");
 	}
 	.fancytree-exp-n span.fancytree-expander, 
 	.fancytree-exp-nl span.fancytree-expander {
@@ -568,7 +567,7 @@ span.fancytree-drop-reject {
 	}
 	&.fancytree-connectors .fancytree-exp-n span.fancytree-expander, 
 	&.fancytree-connectors .fancytree-exp-nl span.fancytree-expander {
-		background-image: url("icons-rtl.gif");
+		background-image: url("@{fancy-image-dir}/icons-rtl.gif");
 	}
 }
 ul.fancytree-container.fancytree-rtl {

--- a/src/skin-lion/ui.fancytree.less
+++ b/src/skin-lion/ui.fancytree.less
@@ -5,6 +5,8 @@
  * the LESS templates.
  */
 
+@fancy-image-dir:'./skin-lion';
+
 /*
  Lion colors:
 	gray highlight bar: #D4D4D4
@@ -32,7 +34,7 @@
 @fancy-icon-spacing: 3px;
 
 // Use 'data-uri(...)' to embed the image into CSS instead of linking to 'loading.gif':
-@fancy-loading-url: data-uri("@{fancy-image-dir}/loading.gif");
+@fancy-loading-url: data-uri("loading.gif");
 // Set to `true` to use `data-uri(...)` which will embed icons.gif into CSS 
 // instead of linking to that file:
 // @fancy-inline-sprites: true;

--- a/src/skin-themeroller/ui.fancytree.less
+++ b/src/skin-themeroller/ui.fancytree.less
@@ -7,6 +7,8 @@
  * the LESS templates.
  */
 
+@fancy-image-dir:'./skin-themeroller';
+
 // Import common styles
 @import "../skin-common.less";
 
@@ -36,7 +38,7 @@
 
 
 // Use 'data-uri(...)' to embed the image into CSS instead of linking to 'loading.gif':
-@fancy-loading-url: data-uri("@{fancy-image-dir}/loading.gif");
+@fancy-loading-url: data-uri("loading.gif");
 // Set to `true` to use `data-uri(...)` which will embed icons.gif into CSS 
 // instead of linking to that file:
 // @fancy-inline-sprites: true;

--- a/src/skin-vista/ui.fancytree.less
+++ b/src/skin-vista/ui.fancytree.less
@@ -5,6 +5,8 @@
  * the LESS templates.
  */
 
+@fancy-image-dir:'./skin-vista';
+
 /*
 both:
    unselected background: #FCFCFC 'nearly white'
@@ -44,7 +46,7 @@ List view:
 @fancy-icon-spacing: 3px;
 
 // Use 'data-uri(...)' to embed the image into CSS instead of linking to 'loading.gif':
-@fancy-loading-url: data-uri("@{fancy-image-dir}/loading.gif");
+@fancy-loading-url: data-uri("loading.gif");
 // Set to `true` to use `data-uri(...)` which will embed icons.gif into CSS 
 // instead of linking to that file:
 // @fancy-inline-sprites: true;

--- a/src/skin-win7/ui.fancytree.less
+++ b/src/skin-win7/ui.fancytree.less
@@ -5,6 +5,8 @@
  * the LESS templates.
  */
 
+@fancy-image-dir:'./skin-win7';
+
 // Fancytree Win7 styles
 
 // both: 
@@ -60,7 +62,7 @@
 @fancy-node-outline-width: 1px;
 
 // Use 'data-uri(...)' to embed the image into CSS instead of linking to 'loading.gif':
-@fancy-loading-url: data-uri("@{fancy-image-dir}/loading.gif");
+@fancy-loading-url: data-uri("loading.gif");
 // Set to `true` to use `data-uri(...)` which will embed icons.gif into CSS 
 // instead of linking to that file:
 // @fancy-inline-sprites: true;

--- a/src/skin-win8-n/ui.fancytree.less
+++ b/src/skin-win8-n/ui.fancytree.less
@@ -5,6 +5,8 @@
  * the LESS templates.
  */
 
+@fancy-image-dir:'./skin-win8-n';
+
 // Import common styles
 @import "../skin-common.less";
 
@@ -44,7 +46,7 @@
 @fancy-icon-spacing: 3px;
 
 // Use 'data-uri(...)' to embed the image into CSS instead of linking to 'loading.gif':
-@fancy-loading-url: data-uri("@{fancy-image-dir}/loading.gif");
+@fancy-loading-url: data-uri("loading.gif");
 // Set to `true` to use `data-uri(...)` which will embed icons.gif into CSS 
 // instead of linking to that file:
 // @fancy-inline-sprites: true;

--- a/src/skin-win8-xxl/ui.fancytree.less
+++ b/src/skin-win8-xxl/ui.fancytree.less
@@ -5,6 +5,8 @@
  * the LESS templates.
  */
 
+@fancy-image-dir:'./skin-win8-xxl';
+
 // Import common styles
 @import "../skin-common.less";
 

--- a/src/skin-win8/ui.fancytree.less
+++ b/src/skin-win8/ui.fancytree.less
@@ -5,6 +5,9 @@
  * the LESS templates.
  */
 
+@fancy-image-dir:'./skin-win8';
+
+
 // Import common styles
 @import "../skin-common.less";
 
@@ -55,7 +58,7 @@
 // @fancy-icon-spacing: 3px;
 
 // Use 'data-uri(...)' to embed the image into CSS instead of linking to 'loading.gif':
-@fancy-loading-url: data-uri("@{fancy-image-dir}/loading.gif");
+@fancy-loading-url: data-uri("loading.gif");
 // Set to `true` to use `data-uri(...)` which will embed icons.gif into CSS 
 // instead of linking to that file:
 // @fancy-inline-sprites: true;

--- a/src/skin-xp/ui.fancytree.less
+++ b/src/skin-xp/ui.fancytree.less
@@ -5,6 +5,8 @@
  * the LESS templates.
  */
 
+@fancy-image-dir:'./skin-xp';
+
 // Import common styles
 @import "../skin-common.less";
 
@@ -26,7 +28,7 @@
 @fancy-node-border-width: 0;
 
 // Use 'data-uri(...)' to embed the image into CSS instead of linking to 'loading.gif':
-@fancy-loading-url: data-uri("@{fancy-image-dir}/loading.gif");
+@fancy-loading-url: data-uri("loading.gif");
 // Set to `true` to use `data-uri(...)` which will embed icons.gif into CSS 
 // instead of linking to that file:
 // @fancy-inline-sprites: true;
@@ -39,7 +41,7 @@ ul.fancytree-container {
 	li {
 		// background-image: url("vline.gif");
 		// Use 'data-uri(...)' to embed the image into CSS instead of linking to 'loading.gif':
-		background-image: data-uri("@{fancy-image-dir}/vline.gif");
+		background-image: data-uri("vline.gif");
 		background-position: 0 0;
 	}
 	&.fancytree-rtl {


### PR DESCRIPTION
Hi,
I have some issues with webpack and path of files caused these problems which webpack and less-loader not able to locate images.
I fixed that problem by define `@fancy-image-dir` variable in each skin and remove definition of it from skin-common.less 