### PR TITLE
Fix regressions from #712

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,7 @@ root = true
 
 [*]
 indent_style = tab
+indent_size = 4
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
@@ -16,7 +17,6 @@ indent_size = 2
 
 [*.js]
 indent_style = tab
-indent_size = 4
 
 [*.coffee]
 indent_style = space
@@ -24,8 +24,6 @@ indent_size = 2
 
 [*.md]
 indent_style = space
-indent_size = 4
 
 [*.py]
 indent_style = space
-indent_size = 4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   * [Fixed] #761: dnd5 throws exception when tree is empty
   * Updated jsdoc to 3.5
 
+# Branch click-folder
+  * Undo commit #712 / #713 to fix regressions #748, #763, #764
+
 # 2.23.0 / 2017-05-27
   * **The external dependency on jQuery UI was removed**.
     A new library `jquery.fancytree-all-deps.min.js` is now added to the

--- a/demo/sample-scroll.html
+++ b/demo/sample-scroll.html
@@ -66,7 +66,10 @@ $.fn.scrollTo = function( target, options, callback ){
 			},
 			lazyLoad: function(event, data) {
 				data.result = {url: "../test/unit/ajax-sub2.json"}
-			}
+			},
+			init: function(event, data) {
+				data.tree.getFirstChild().setFocus();
+			},
 			// expand: function(event, data){
 			// 	// scroll down to last node, but keep current node visible
 			// 	data.node.getLastChild().scrollIntoView(true, {topNode: data.node});

--- a/src/jquery.fancytree.js
+++ b/src/jquery.fancytree.js
@@ -4375,12 +4375,6 @@ $.extend(Fancytree.prototype,
 	 * @param {boolean} [flag=true]
 	 */
 	treeSetFocus: function(ctx, flag, callOpts) {
-		function ensureTreeFocus(thisTree) {
-			if (!thisTree.activeNode && thisTree.getFirstChild()) {
-				thisTree.getFirstChild().setFocus();
-			}
-		}
-
 		flag = (flag !== false);
 
 		// this.debug("treeSetFocus(" + flag + "), callOpts: ", callOpts, this.hasFocus());
@@ -4396,11 +4390,8 @@ $.extend(Fancytree.prototype,
 			}
 			this.$container.toggleClass("fancytree-treefocus", flag);
 			this._triggerTreeEvent(flag ? "focusTree" : "blurTree");
-			if( flag ) {
-				// Check after timeout to ensure mousedown processing is complete
-				// and the clicked node is already activated
-				var thisTree = this;
-				setTimeout(function() { ensureTreeFocus(thisTree); }, 0);
+			if( flag && !this.activeNode ) {
+				this.getFirstChild() && this.getFirstChild().setFocus();
 			}
 		}
 	},
@@ -4701,7 +4692,7 @@ $.widget("ui.fancytree",
 			} finally {
 				tree.phase = prevPhase;
 			}
-		}).on("mousedown" + ns + " dblclick" + ns, function(event){
+		}).on("click" + ns + " dblclick" + ns, function(event){
 			// that.tree.debug("event(" + event + "): !");
 			if(opts.disabled){
 				return true;
@@ -4721,7 +4712,7 @@ $.widget("ui.fancytree",
 			try {
 				tree.phase = "userEvent";
 				switch(event.type) {
-				case "mousedown":
+				case "click":
 					ctx.targetType = et.type;
 					if( node.isPagingNode() ) {
 						return tree._triggerNodeEvent("clickPaging", ctx, event) === true;

--- a/src/jquery.fancytree.js
+++ b/src/jquery.fancytree.js
@@ -4394,6 +4394,7 @@ $.extend(Fancytree.prototype,
 			this.$container.toggleClass("fancytree-treefocus", flag);
 			this._triggerTreeEvent(flag ? "focusTree" : "blurTree");
 			if( flag && !this.activeNode ) {
+				// #712: Use last mousedowned node ('click' event fires after focusin)
 				targetNode = this._lastMousedownNode || this.getFirstChild();
 				targetNode && targetNode.setFocus();
 			}
@@ -4700,9 +4701,10 @@ $.widget("ui.fancytree",
 			}
 
 		}).on("mousedown" + ns, function(event){
-			// #412: store the clicked node, so we can use it when we get a focusin event
 			var et = FT.getEventTarget(event);
-			that.tree.debug("event(" + event.type + "): node: ", et.node);
+			// that.tree.debug("event(" + event.type + "): node: ", et.node);
+			// #712: Store the clicked node, so we can use it when we get a focusin event
+			//       ('click' event fires after focusin)
 			that.tree._lastMousedownNode = et ? et.node : null;
 
 		}).on("click" + ns + " dblclick" + ns, function(event){
@@ -4715,7 +4717,7 @@ $.widget("ui.fancytree",
 				tree = that.tree,
 				prevPhase = tree.phase;
 
-			that.tree.debug("event(" + event.type + "): node: ", node);
+			// that.tree.debug("event(" + event.type + "): node: ", node);
 			if( !node ){
 				return true;  // Allow bubbling of other events
 			}

--- a/test/unit/test-core.js
+++ b/test/unit/test-core.js
@@ -644,7 +644,7 @@ QUnit.test("makeVisible not rendered deep node", function(assert) {
  */
 QUnit.module("events");
 
-QUnit.test(".mousedown() to expand a folder", function(assert) {
+QUnit.test(".click() to expand a folder", function(assert) {
 	tools.setup(assert);
 	assert.expect(8);
 
@@ -667,11 +667,11 @@ QUnit.test(".mousedown() to expand a folder", function(assert) {
 			done();
 		}
 	});
-	$("#tree #ft_10 span.fancytree-expander").mousedown();
+	$("#tree #ft_10 span.fancytree-expander").click();
 });
 
 
-QUnit.test(".mousedown() to activate a node", function(assert) {
+QUnit.test(".click() to activate a node", function(assert) {
 	tools.setup(assert);
 	assert.expect(8);
 
@@ -694,11 +694,11 @@ QUnit.test(".mousedown() to activate a node", function(assert) {
 			done();
 		}
 	});
-	$("#tree #ft_2 span.fancytree-title").mousedown();
+	$("#tree #ft_2 span.fancytree-title").click();
 });
 
 
-QUnit.test(".mousedown() to activate a folder (clickFolderMode 3 triggers expand)", function(assert) {
+QUnit.test(".click() to activate a folder (clickFolderMode 3 triggers expand)", function(assert) {
 	tools.setup(assert);
 	assert.expect(4);
 
@@ -723,11 +723,11 @@ QUnit.test(".mousedown() to activate a folder (clickFolderMode 3 triggers expand
 			done();
 		}
 	});
-	$("#tree #ft_10 span.fancytree-title").mousedown();
+	$("#tree #ft_10 span.fancytree-title").click();
 });
 
 
-QUnit.test(".mousedown() to select a node", function(assert) {
+QUnit.test(".click() to select a node", function(assert) {
 	tools.setup(assert);
 	assert.expect(8);
 
@@ -751,7 +751,7 @@ QUnit.test(".mousedown() to select a node", function(assert) {
 			done();
 		}
 	});
-	$("#tree #ft_2 span.fancytree-checkbox").mousedown();
+	$("#tree #ft_2 span.fancytree-checkbox").click();
 });
 
 
@@ -950,7 +950,7 @@ QUnit.test("selectMode: 3", function(assert) {
  */
 QUnit.module("lazy loading");
 
-QUnit.test("Using ajax options for `source`; .mousedown() expands a lazy folder", function(assert) {
+QUnit.test("Using ajax options for `source`; .click() expands a lazy folder", function(assert) {
 	tools.setup(assert);
 	assert.expect(19);
 
@@ -967,7 +967,7 @@ QUnit.test("Using ajax options for `source`; .mousedown() expands a lazy folder"
 			assert.equal($("#tree li").length, TESTDATA_VISIBLENODES, "lazy tree has rendered 13 node elements");
 			// now expand a lazy folder
 			isClicked = true;
-			$("#tree #ft_30 span.fancytree-expander").mousedown();
+			$("#tree #ft_30 span.fancytree-expander").click();
 		},
 		beforeExpand: function(event, data){
 			assert.equal(sequence++, 4, "receive `beforeExpand` callback");
@@ -1007,8 +1007,7 @@ QUnit.test("Using ajax options for `source`; .mousedown() expands a lazy folder"
 	});
 });
 
-
-QUnit.test("Using $.ajax promise for `source`; .mousedown() expands a lazy folder", function(assert) {
+QUnit.test("Using $.ajax promise for `source`; .click() expands a lazy folder", function(assert) {
 	tools.setup(assert);
 	assert.expect(12);
 
@@ -1028,7 +1027,7 @@ QUnit.test("Using $.ajax promise for `source`; .mousedown() expands a lazy folde
 			assert.equal($("#tree li").length, TESTDATA_VISIBLENODES, "lazy tree has rendered 13 node elements");
 			// now expand a lazy folder
 			isClicked = true;
-			$("#tree #ft_30 span.fancytree-expander").mousedown();
+			$("#tree #ft_30 span.fancytree-expander").click();
 		},
 		beforeExpand: function(event, data){
 			assert.equal(sequence++, 3, "receive `beforeExpand` callback");


### PR DESCRIPTION
The original PR #713 implemented node focus and activation based on mousedown instead of click events. This introduced some regressions.
The new implementation now uses the click events again, but records the requested entering node in the mousedown event (which - unlike the click event - fires before focusin).