### PR TITLE
fa-cog isn't centered when it's spinning for admin templates

### DIFF
--- a/src/jquery.fancytree.glyph.js
+++ b/src/jquery.fancytree.glyph.js
@@ -9,8 +9,8 @@
  * Released under the MIT license
  * https://github.com/mar10/fancytree/wiki/LicenseInfo
  *
- * @version 2.24.0
- * @date 2017-08-26T13:42:51Z
+ * @version @VERSION
+ * @date @DATE
  */
 
 ;(function($, window, document, undefined) {
@@ -94,10 +94,9 @@ function _removeSpanIcon(span) {
     if (span && $(span).find('i'))
         $(span).find('i').remove();
 }
-
 $.ui.fancytree.registerExtension({
 	name: "glyph",
-	version: "2.24.0",
+	version: "@VERSION",
 	// Default options for this extension.
 	options: {
 		preset: null,  // 'awesome3', 'awesome4', 'bootstrap3'
@@ -131,7 +130,6 @@ $.ui.fancytree.registerExtension({
 		if( node.isRoot() ){
 			return res;
 		}
-        
 		span = $span.children("span.fancytree-expander").get(0);
 		if( span ){
 			// if( node.isLoading() ){
@@ -148,7 +146,6 @@ $.ui.fancytree.registerExtension({
 			span.className = "fancytree-expander " + map[icon];
 		}
 		_removeSpanIcon(span);
-
 		if( node.tr ){
 			span = $("td", node.tr).find("span.fancytree-checkbox").get(0);
 		}else{
@@ -159,7 +156,6 @@ $.ui.fancytree.registerExtension({
 			span.className = "fancytree-checkbox " + map[icon];
 		}
 		_removeSpanIcon(span);
-
 		// Standard icon (note that this does not match .fancytree-custom-icon,
 		// that might be set by opts.icon callbacks)
 		span = $span.children("span.fancytree-icon").get(0);
@@ -174,7 +170,6 @@ $.ui.fancytree.registerExtension({
 			span.className = "fancytree-icon " + icon;
 		}
 		_removeSpanIcon(span);
-
 		return res;
 	},
 	nodeSetStatus: function(ctx, status, message, details) {
@@ -184,28 +179,27 @@ $.ui.fancytree.registerExtension({
 
 		res = this._superApply(arguments);
 
-		if (status === "error" || status === "loading" || status === "nodata") {
-            /*
+		if( status === "error" || status === "loading" || status === "nodata" ){
+			   /*
              * Wrap the icons inside the span. Instead of appending to the same span 
              */
 		    var icon=$('<i />', {
 		        "class": ''
 		    });
-
-
+			
 			if(node.parent){
 				span = $("span.fancytree-expander", node.span).get(0);
 				if( span ) {
-				    span.className = "fancytree-expander";
-				    $(icon).addClass(_getIcon(opts, status))
+					span.className = "fancytree-expander ";
+					$(icon).addClass(_getIcon(opts, status))
 				    $(span).html($(icon));
 				}
 			}else{ //
 				span = $(".fancytree-statusnode-" + status, node[this.nodeContainerAttrName])
 					.find("span.fancytree-icon").get(0);
 				if( span ) {
-				    span.className = "fancytree-icon ";
-				    $(icon).addClass(_getIcon(opts, status));
+					span.className = "fancytree-icon ";
+					$(icon).addClass(_getIcon(opts, status))
 				    $(span).html($(icon));
 				}
 			}

--- a/src/jquery.fancytree.glyph.js
+++ b/src/jquery.fancytree.glyph.js
@@ -91,8 +91,11 @@ function _getIcon(opts, type){
 }
 
 function _removeSpanIcon(span) {
-    if (span && $(span).find('i'))
-        $(span).find('i').remove();
+    if (span && $(span).find("i"))
+	{
+		$(span).find("i").remove();
+	}
+        
 }
 $.ui.fancytree.registerExtension({
 	name: "glyph",
@@ -183,15 +186,15 @@ $.ui.fancytree.registerExtension({
 			   /*
              * Wrap the icons inside the span. Instead of appending to the same span 
              */
-		    var icon=$('<i />', {
-		        "class": ''
+		    var icon=$("<i />", {
+		        "class": ""
 		    });
 			
 			if(node.parent){
 				span = $("span.fancytree-expander", node.span).get(0);
 				if( span ) {
 					span.className = "fancytree-expander ";
-					$(icon).addClass(_getIcon(opts, status))
+					$(icon).addClass(_getIcon(opts, status));
 				    $(span).html($(icon));
 				}
 			}else{ //
@@ -199,7 +202,7 @@ $.ui.fancytree.registerExtension({
 					.find("span.fancytree-icon").get(0);
 				if( span ) {
 					span.className = "fancytree-icon ";
-					$(icon).addClass(_getIcon(opts, status))
+					$(icon).addClass(_getIcon(opts, status));
 				    $(span).html($(icon));
 				}
 			}

--- a/src/jquery.fancytree.glyph.js
+++ b/src/jquery.fancytree.glyph.js
@@ -9,8 +9,8 @@
  * Released under the MIT license
  * https://github.com/mar10/fancytree/wiki/LicenseInfo
  *
- * @version @VERSION
- * @date @DATE
+ * @version 2.24.0
+ * @date 2017-08-26T13:42:51Z
  */
 
 ;(function($, window, document, undefined) {
@@ -90,10 +90,14 @@ function _getIcon(opts, type){
 	return opts.map[type];
 }
 
+function _removeSpanIcon(span) {
+    if (span && $(span).find('i'))
+        $(span).find('i').remove();
+}
 
 $.ui.fancytree.registerExtension({
 	name: "glyph",
-	version: "@VERSION",
+	version: "2.24.0",
 	// Default options for this extension.
 	options: {
 		preset: null,  // 'awesome3', 'awesome4', 'bootstrap3'
@@ -127,6 +131,7 @@ $.ui.fancytree.registerExtension({
 		if( node.isRoot() ){
 			return res;
 		}
+        
 		span = $span.children("span.fancytree-expander").get(0);
 		if( span ){
 			// if( node.isLoading() ){
@@ -142,6 +147,7 @@ $.ui.fancytree.registerExtension({
 			}
 			span.className = "fancytree-expander " + map[icon];
 		}
+		_removeSpanIcon(span);
 
 		if( node.tr ){
 			span = $("td", node.tr).find("span.fancytree-checkbox").get(0);
@@ -152,6 +158,7 @@ $.ui.fancytree.registerExtension({
 			icon = node.selected ? "checkboxSelected" : (node.partsel ? "checkboxUnknown" : "checkbox");
 			span.className = "fancytree-checkbox " + map[icon];
 		}
+		_removeSpanIcon(span);
 
 		// Standard icon (note that this does not match .fancytree-custom-icon,
 		// that might be set by opts.icon callbacks)
@@ -166,6 +173,8 @@ $.ui.fancytree.registerExtension({
 			}
 			span.className = "fancytree-icon " + icon;
 		}
+		_removeSpanIcon(span);
+
 		return res;
 	},
 	nodeSetStatus: function(ctx, status, message, details) {
@@ -175,17 +184,29 @@ $.ui.fancytree.registerExtension({
 
 		res = this._superApply(arguments);
 
-		if( status === "error" || status === "loading" || status === "nodata" ){
+		if (status === "error" || status === "loading" || status === "nodata") {
+            /*
+             * Wrap the icons inside the span. Instead of appending to the same span 
+             */
+		    var icon=$('<i />', {
+		        "class": ''
+		    });
+
+
 			if(node.parent){
 				span = $("span.fancytree-expander", node.span).get(0);
 				if( span ) {
-					span.className = "fancytree-expander " + _getIcon(opts, status);
+				    span.className = "fancytree-expander";
+				    $(icon).addClass(_getIcon(opts, status))
+				    $(span).html($(icon));
 				}
 			}else{ //
 				span = $(".fancytree-statusnode-" + status, node[this.nodeContainerAttrName])
 					.find("span.fancytree-icon").get(0);
 				if( span ) {
-					span.className = "fancytree-icon " + _getIcon(opts, status);
+				    span.className = "fancytree-icon ";
+				    $(icon).addClass(_getIcon(opts, status));
+				    $(span).html($(icon));
 				}
 			}
 		}


### PR DESCRIPTION
There is a loading symbol issue for some other designs. So wrapped the icons inside the span instead of adding the class.

https://github.com/mar10/fancytree/issues/770