### PR TITLE
Strip out the AMD related code from jQuery-UI from jquery.fancytree-all-deps.min.js

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -121,6 +121,9 @@ module.exports = (grunt) ->
                   # (but keep disclaimer for jQuery-UI)
                   if not /jquery-ui..+.min.js/.test(fspec)
                       src = src.replace(/\/\*(.|\n)*\*\//g, "")
+                  # strip out AMD related code from jQuery-UI and make it an IIFE
+                  if /jquery-ui..+.min.js/.test(fspec)
+                      src = src.replace(/\(function.+jQuery\)}\)\((.+\)}\)})\);/, "!$1(jQuery);")
                   if /jquery.fancytree.min.js/.test(fspec)
                       src = "\n/*! Fancytree Core */" + src
                   if /fancytree..+.min.js/.test(fspec)


### PR DESCRIPTION
Strip out the AMD related code from jQuery-UI when building jquery.fancytree-all-deps.min.js and converts it to an IIFE.