### PR TITLE
Make "partsel" attribute set "fancytree-partsel" class

### DIFF
--- a/src/jquery.fancytree.js
+++ b/src/jquery.fancytree.js
@@ -73,7 +73,7 @@ var i, attr,
 	TREE_ATTRS = "columns types".split(" "),
 	// TREE_ATTR_MAP = {},
 	// Top-level FancytreeNode attributes, that can be set by dict
-	NODE_ATTRS = "checkbox expanded extraClasses folder icon iconTooltip key lazy radiogroup refKey selected statusNodeType title tooltip type unselectable unselectableIgnore unselectableStatus".split(" "),
+	NODE_ATTRS = "checkbox expanded extraClasses folder icon iconTooltip key lazy radiogroup refKey selected statusNodeType title tooltip type unselectable unselectableIgnore unselectableStatus partsel".split(" "),
 	NODE_ATTR_MAP = {},
 	// Mapping of lowercase -> real name (because HTML5 data-... attribute only supports lowercase)
 	NODE_ATTR_LOWERCASE_MAP = {},


### PR DESCRIPTION
If "partsel" is set to true, then node gets "fancytree-partsel" CSS attribute. This makes possible to show ajax loaded node as it's not all children are selected.