### PR TITLE
debugLevel = 0 will never throw any messages on console

### DIFF
--- a/src/jquery.fancytree.js
+++ b/src/jquery.fancytree.js
@@ -108,7 +108,7 @@ function consoleApply(method, args){
 	var i, s,
 		fn = window.console ? window.console[method] : null;
 
-	if(fn){
+	if(fn && $.ui.fancytree.debugLevel !==0){
 		try{
 			fn.apply(window.console, args);
 		} catch(e) {


### PR DESCRIPTION
debugLevel = 0 
should have highest priority and should never output anything to console
 #828 