### PR TITLE
Do not select if unselectable is true

### DIFF
--- a/src/jquery.fancytree.js
+++ b/src/jquery.fancytree.js
@@ -833,6 +833,7 @@ FancytreeNode.prototype = /** @lends FancytreeNode# */{
 			}
 		});
 		this.fixSelection3FromEndNodes(callOpts);
+		this._changeSelectStatusAttrs(flag);
 	},
 	/**
 	 * Fix selection status for multi-hier mode.

--- a/src/jquery.fancytree.js
+++ b/src/jquery.fancytree.js
@@ -828,7 +828,9 @@ FancytreeNode.prototype = /** @lends FancytreeNode# */{
 //		this.debug("fixSelection3AfterClick()");
 
 		this.visit(function(node){
-			node._changeSelectStatusAttrs(flag);
+			if (!node.unselectable) {
+				node._changeSelectStatusAttrs(flag);
+			}
 		});
 		this.fixSelection3FromEndNodes(callOpts);
 	},


### PR DESCRIPTION
Calling `fixSelection3AfterClick` selects all child items even if `unselectable` set to true for the child node. This PR fixes that.