### PR TITLE
If drag does not start, no drag data should be stored.

### DIFF
--- a/dist/modules/jquery.fancytree.dnd5.js
+++ b/dist/modules/jquery.fancytree.dnd5.js
@@ -599,12 +599,7 @@
 								}
 							}
 							// Let user modify above settings
-							if (dndOpts.dragStart(node, data) !== false) {
-								return true;
-							}
-							// Clear dragged node to be safe
-							_clearGlobals();
-							return false;
+							return dndOpts.dragStart(node, data) !== false;		 							if (dndOpts.dragStart(node, data) !== false) {
 
 						case "drag":
 							// Called every few miliseconds

--- a/dist/modules/jquery.fancytree.dnd5.js
+++ b/dist/modules/jquery.fancytree.dnd5.js
@@ -599,7 +599,7 @@
 								}
 							}
 							// Let user modify above settings
-							return dndOpts.dragStart(node, data) !== false;		 							if (dndOpts.dragStart(node, data) !== false) {
+							return dndOpts.dragStart(node, data) !== false;
 
 						case "drag":
 							// Called every few miliseconds

--- a/dist/modules/jquery.fancytree.dnd5.js
+++ b/dist/modules/jquery.fancytree.dnd5.js
@@ -599,7 +599,12 @@
 								}
 							}
 							// Let user modify above settings
-							return dndOpts.dragStart(node, data) !== false;
+							if (dndOpts.dragStart(node, data) !== false) {
+								return true;
+							}
+							// Clear dragged node to be safe
+							_clearGlobals();
+							return false;
 
 						case "drag":
 							// Called every few miliseconds

--- a/src/jquery.fancytree.dnd5.js
+++ b/src/jquery.fancytree.dnd5.js
@@ -607,7 +607,7 @@
 							// Clear dragged node to be safe
 							_clearGlobals();
 							return false;
-							
+
 						case "drag":
 							// Called every few miliseconds
 							// data.tree.info("drag", SOURCE_NODE)

--- a/src/jquery.fancytree.dnd5.js
+++ b/src/jquery.fancytree.dnd5.js
@@ -601,13 +601,12 @@
 								}
 							}
 							// Let user modify above settings
-							if (dndOpts.dragStart(node, data)!==false) {
+							if (dndOpts.dragStart(node, data) !== false) {
 								return true;
-							} else {
-								// Clear dragged node to be safe
-								_clearGlobals();
-								return false;
 							}
+							// Clear dragged node to be safe
+							_clearGlobals();
+							return false;
 							
 						case "drag":
 							// Called every few miliseconds

--- a/src/jquery.fancytree.dnd5.js
+++ b/src/jquery.fancytree.dnd5.js
@@ -601,8 +601,14 @@
 								}
 							}
 							// Let user modify above settings
-							return dndOpts.dragStart(node, data) !== false;
-
+							if (dndOpts.dragStart(node, data)!==false) {
+								return true;
+							} else {
+								// Clear dragged node to be safe
+								_clearGlobals();
+								return false;
+							}
+							
 						case "drag":
 							// Called every few miliseconds
 							// data.tree.info("drag", SOURCE_NODE)


### PR DESCRIPTION
I had an issue that after trying to drag a node (which returns false, so drag does not start),
then dragging something other then a node onto the tree returns the previously dragged node in data.otherNode instead of null. So I added a _clearGlobal in case dragStart returns false.