### PR TITLE
feature to filter not only by title, but also by additional text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 2.31.0-0 / Unreleased
+  * Added feature to filter not only by title, but also by additional text - placed in `searchable` field of the tree nodes.
   * **ext-grid** (experimental)<br>
     The new `ext-grid` extension is a variant of `ext-table` that introduces viewport support.
     This allows to maintain *huge* data models while only rendering as many DOM elements as necessary.<br>

--- a/src/jquery.fancytree.filter.js
+++ b/src/jquery.fancytree.filter.js
@@ -95,6 +95,9 @@
 				var text = escapeTitles
 						? node.title
 						: extractHtmlText(node.title),
+					matchText = escapeTitles
+						? node.title + " " + node.data.searchable
+						: extractHtmlText(node.title + " " + node.data.searchable),
 					res = !!re.test(text);
 
 				if (res && opts.highlight) {

--- a/src/jquery.fancytree.filter.js
+++ b/src/jquery.fancytree.filter.js
@@ -98,7 +98,7 @@
 					matchText = escapeTitles
 						? node.title + " " + node.data.searchable
 						: extractHtmlText(node.title + " " + node.data.searchable),
-					res = !!re.test(text);
+					res = !!re.test(matchText);
 
 				if (res && opts.highlight) {
 					if (escapeTitles) {


### PR DESCRIPTION
Added feature to filter not only by title, but also by additional text - placed in `searchable` field of the tree nodes.
