### PR TITLE
Fix: focus() with option preventScroll must be called on the dom elem…

### DIFF
--- a/src/jquery.fancytree.edit.js
+++ b/src/jquery.fancytree.edit.js
@@ -217,7 +217,7 @@
 		}
 
 		// Set keyboard focus, even if setFocus() claims 'nothing to do'
-		$(tree.$container).focus({ preventScroll: true });
+		tree.$container.get(0).focus({ preventScroll: true });
 		eventData.input = null;
 		instOpts.close.call(node, { type: "close" }, eventData);
 		return true;


### PR DESCRIPTION
…ent.

This should fix #1028 (regression came in with #1019)