### PR TITLE
When tree has no focus, the first click on expander or checkbox is ignored (ext-glyph and SVG) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
     * Improved padding and alignment for skin-awesome icons
     * Allow to pass a callback() as `glyph.map<TYPE>` option
     * Update Fontwesome demos to v5.0.13
+    * #1033 When tree has no focus and SVG is used, the first click on expander
+      or checkbox is ignored
   * [Changed] #1025 ext-dnd5: changed behavior when `dndOpts.multiSource` is
     true. Now dragging an unselected node will only drag that single node (while
     keeping the other nodes selected). You have to drag one of the *selected*

--- a/src/jquery.fancytree.js
+++ b/src/jquery.fancytree.js
@@ -6517,7 +6517,7 @@
 								// #789: IE 11 may send focusin before mousdown(?)
 								node = tree._getExpiringValue("mouseDownNode");
 								if (node) {
-									tree.debug(
+									node.debug(
 										"Reconstruct mouse target for focusin from recent event."
 									);
 								}
@@ -6591,7 +6591,7 @@
 					})
 					.on("mousedown" + ns, function(event) {
 						var et = FT.getEventTarget(event);
-						// self.tree.debug("event(" + event.type + "): node: ", et.node);
+						// self.tree.debug("event(" + event.type + "): node: ", et.node, et);
 						// #712: Store the clicked node, so we can use it when we get a focusin event
 						//       ('click' event fires after focusin)
 						// tree.debug("event(" + event.type + "): node: ", et.node);
@@ -6613,7 +6613,7 @@
 							tree = self.tree,
 							prevPhase = tree.phase;
 
-						// self.tree.debug("event(" + event.type + "): node: ", node);
+						// self.tree.debug("event(" + event.type + "): node: ", node, et);
 						if (!node) {
 							return true; // Allow bubbling of other events
 						}


### PR DESCRIPTION
See #1033 