### PR TITLE
Fix invalid rendering second table if using two or more tree on one t…

### DIFF
--- a/src/jquery.fancytree.fixed.js
+++ b/src/jquery.fancytree.fixed.js
@@ -380,7 +380,7 @@
 				node = ctx.node,
 				isRootNode = !node.parent;
 
-			if (!isRootNode) {
+			if (!isRootNode && this.$fixedWrapper) {
 				var $trLeft = $(node.tr),
 					fcn = this.options.fixed.classNames,
 					$trRight = $trLeft.data(fcn.counterpart);
@@ -388,10 +388,10 @@
 				if (!$trRight && $trLeft.length) {
 					var idx = $trLeft.index(),
 						fixedColCount = this.options.fixed.fixCols,
-						$blTableBody = $(
+						$blTableBody = this.$fixedWrapper.find(
 							"div." + fcn.bottomLeft + " table tbody"
 						),
-						$brTableBody = $(
+						$brTableBody = this.$fixedWrapper.find(
 							"div." + fcn.bottomRight + " table tbody"
 						),
 						$prevLeftNode = $blTableBody


### PR DESCRIPTION
Fix invalid rendering second table if using two or more tree on one page 

[Reported bug](https://github.com/mar10/fancytree/issues/976)