### PR TITLE
Fix jQuery cookie set function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 2.38.2-0 / Unreleased
+  * [Fixed] #1097 Removed incorrect set-function for jQuery cookie
 
 # 2.38.1-0 / 2022-01-14
   * Replace deprecated jQuery functions: `$.isArray()`, `$.isFunction()`,

--- a/src/jquery.fancytree.persist.js
+++ b/src/jquery.fancytree.persist.js
@@ -92,7 +92,7 @@
 		cookieStore = {
 			get: $.cookie,
 			set: function (key, value) {
-				$.cookie.set(key, value, this.options.persist.cookie);
+				$.cookie(key, value, this.options.persist.cookie);
 			},
 			remove: $.removeCookie,
 		};


### PR DESCRIPTION
Currently, when using jQuery cookie as persist cookie store, it throws an error that the set function does not exist.
That can be tested with `demo/sample-ext-persist.html` when using jQuery Cookie.  
It seems that bug comes due following commit fdde567ac77d7918a673653240bf0185109ab924 and exists since version 2.27.0.

