### PR TITLE
finetune the vline of skin xp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 2.38.4-0 / Unreleased
+  * [Changed] #1143 Improve the appearance of vertical connectors of skin XP
 
 # 2.38.3 / 2023-02-01
   * #1113 Update jQuery UI to 1.13.2

--- a/src/skin-xp/ui.fancytree.less
+++ b/src/skin-xp/ui.fancytree.less
@@ -24,6 +24,7 @@
 @fancy-icon-height: 16px;
 @fancy-icon-spacing: 3px;
 @fancy-node-border-width: 0;
+@fancy-node-v-spacing: 0px;    // no gap as it interrupts the vline
 
 // We need to define this variable here (not in skin-common.less) to make it
 // work with grunt and webpack:
@@ -44,11 +45,11 @@ ul.fancytree-container {
 		// background-image: url("vline.gif");
 		// Use 'data-uri(...)' to embed the image into CSS instead of linking to 'loading.gif':
 		background-image: data-uri("@{fancy-image-prefix}vline.gif");
-		background-position: 0 0;
+		background-position: 0 1px;
 	}
 	&.fancytree-rtl {
 		li {
-			background-position: right 0;
+			background-position: right 1px;
 			background-image: url("@{fancy-image-prefix}vline-rtl.gif");
 		}
 		.fancytree-exp-n span.fancytree-expander {


### PR DESCRIPTION
- The top margin introduces interruptions of the vline. Use e.g. line-height (with an even value) for wider spacing.
- The vline image overlaps with the expander images, but dots were moved relatively, such that it is shown as solid line there. Solved by one 1px shift.